### PR TITLE
fix boolean state

### DIFF
--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -31,9 +31,9 @@ export const useSsrState = <T>(defaultValue: T, id?: string): [T, (componentStat
 
   const appStateFragment: T = useMemo<T>(
     () => (
-      !initState[key] ?
-        defaultValue :
-        initState[key]
+      typeof initState[key] === 'boolean' || initState[key] ?
+        initState[key] :
+        defaultValue
     ),
     [initState, key, defaultValue]
   );


### PR DESCRIPTION
boolean state not work correctly

example:
const [isLoading, setIsLoading] = useSsrState(true);
useSsrEffect(async () => {
    setIsLoading(false);
});

isLoading - alway "true"